### PR TITLE
add function to support custom data when adding user to group

### DIFF
--- a/lib/fusion_auth/groups.ex
+++ b/lib/fusion_auth/groups.ex
@@ -163,6 +163,15 @@ defmodule FusionAuth.Groups do
     do: add_members(client, group_id, [member])
 
   @doc """
+  Add member to a group by user_id with custom data
+
+  For more information visit the FusionAuth API Documentation for [Add Users to a Group](https://fusionauth.io/docs/v1/tech/apis/groups#add-users-to-a-group)
+  """
+  @spec add_member(client(), group_id(), user_id(), map()) :: result()
+  def add_member(client, group_id, user_id, data \\ %{}) when is_binary(user_id),
+    do: add_members(client, group_id, [%{userId: user_id, data: data}])
+
+  @doc """
   Add multiple members to a group.
 
   For more information visit the FusionAuth API Documentation for [Add Users to a Group](https://fusionauth.io/docs/v1/tech/apis/groups#add-users-to-a-group)

--- a/test/fusion_auth/groups_test.exs
+++ b/test/fusion_auth/groups_test.exs
@@ -37,6 +37,13 @@ defmodule FusionAuth.GroupsTest do
     "userId" => @user_id
   }
 
+  @member_with_data %{
+    "data" => %{"name" => "test group"},
+    "id" => @member_id,
+    "insertInstant" => 1_591_303_565_005,
+    "userId" => @user_id
+  }
+
   setup do
     api_key = "sQ9wwELaI0whHQqyQUxAJmZvVzZqUL-hpfmAmPgbIu8"
     tenant_id = "6b40f9d6-cfd8-4312-bff8-b082ad45e93c"
@@ -231,6 +238,28 @@ defmodule FusionAuth.GroupsTest do
 
       {:ok, %{"members" => %{@group_id => [member]}}, _} =
         Groups.add_member(client, @group_id, member)
+
+      assert member["userId"] == @user_id
+    end
+  end
+
+  describe "add_member/4" do
+    test "add member by user_id with custom data", %{client: client} do
+      Mock.mock_request(
+        path: @members_url,
+        method: :post,
+        status: 200,
+        response_body: %{
+          "members" => %{
+            @group_id => [@member_with_data]
+          }
+        }
+      )
+
+      data = %{name: "test group"}
+
+      {:ok, %{"members" => %{@group_id => [member]}}, _} =
+        Groups.add_member(client, @group_id, @user_id, data)
 
       assert member["userId"] == @user_id
     end


### PR DESCRIPTION
### Use case
By default, the names of the groups a user belongs to (under `user.memberships`) are not available when fetching the user object as of FusionAuth 1.17.
This added function, `FusionAuth.Groups.add_member/4` would allow devs to specify custom attributes upon adding the user to a group via the `data` object.

### Example
A common use case is to have the group names whose user belongs when fetching a user.
To accomplish this, add the user to the group `FusionAuth.Groups.add_member(client, group_id, user_id, data)`, where data is a map, and can be something like this:
```elixir
data = %{name: "some-group-name"}
```
After the user is added to the group, when devs fetch for the user object, the added custom attribute(s) will be available and thereby accomplishing the task in one network request and avoiding multiple roundtrips to FusionAuth's API.