### PR TITLE
chore(service-upgrade/fusionauth-1.46.0): [VR-14247] upgrade FusionAuth to 1.46.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,14 @@ services:
     # GOOD      Upgrading to 1.45.4 works with some minor test tweaks.
     # GOOD      Upgrading to 1.46.0 works with no additional test tweaks.
     # ISSUES    Upgrading to 1.47.1 has some odd test errors show up.
+    # ISSUES    Upgrading to 1.48.3 returns 401 for some JWT endpoints that are currently in use.
+    #               JWT.validate
+    #               JWT.issue_jwt_by_application_id 
+    #               TwoFactor.generate_secret_for_jwt
     # ISSUES    Upgrading to 1.49.2 returns 401 for some JWT endpoints that are currently in use.
     #               JWT.validate
     #               JWT.issue_jwt_by_application_id
+    #               TwoFactor.generate_secret_for_jwt
     image: fusionauth/fusionauth-app:1.46.0
     environment:
       DATABASE_URL: jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/fusionauth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,19 +40,6 @@ services:
 
   fusionauth:
     container_name: fa-test-fusionauth
-    # GOOD      Upgrading to 1.40 works with some minor test tweaks.
-    # ISSUES    Upgrading to 1.45 returns 401 for some JWT endpoints that are currently in use.
-    # GOOD      Upgrading to 1.45.4 works with some minor test tweaks.
-    # GOOD      Upgrading to 1.46.0 works with no additional test tweaks.
-    # ISSUES    Upgrading to 1.47.1 has some odd test errors show up.
-    # ISSUES    Upgrading to 1.48.3 returns 401 for some JWT endpoints that are currently in use.
-    #               JWT.validate
-    #               JWT.issue_jwt_by_application_id 
-    #               TwoFactor.generate_secret_for_jwt
-    # ISSUES    Upgrading to 1.49.2 returns 401 for some JWT endpoints that are currently in use.
-    #               JWT.validate
-    #               JWT.issue_jwt_by_application_id
-    #               TwoFactor.generate_secret_for_jwt
     image: fusionauth/fusionauth-app:1.46.0
     environment:
       DATABASE_URL: jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/fusionauth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,11 @@ services:
     # GOOD      Upgrading to 1.40 works with some minor test tweaks.
     # ISSUES    Upgrading to 1.45 returns 401 for some JWT endpoints that are currently in use.
     # GOOD      Upgrading to 1.45.4 works with some minor test tweaks.
-    image: fusionauth/fusionauth-app:1.45.4
+    # GOOD      Upgrading to 1.46.0 works with no additional test tweaks.
+    # ISSUES    Upgrading to 1.49.2 returns 401 for some JWT endpoints that are currently in use.
+    #               JWT.validate
+    #               JWT.issue_jwt_by_application_id
+    image: fusionauth/fusionauth-app:1.46.0
     environment:
       DATABASE_URL: jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/fusionauth
       DATABASE_ROOT_USERNAME: ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     # ISSUES    Upgrading to 1.45 returns 401 for some JWT endpoints that are currently in use.
     # GOOD      Upgrading to 1.45.4 works with some minor test tweaks.
     # GOOD      Upgrading to 1.46.0 works with no additional test tweaks.
+    # ISSUES    Upgrading to 1.47.1 has some odd test errors show up.
     # ISSUES    Upgrading to 1.49.2 returns 401 for some JWT endpoints that are currently in use.
     #               JWT.validate
     #               JWT.issue_jwt_by_application_id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     container_name: fa-test-fusionauth
     # ISSUES    Upgrading to 45 returns 401 for some JWT endpoints that are currently in use.
     # GOOD      Upgrading to 40 works with some minor test tweaks.
-    image: fusionauth/fusionauth-app:1.40.0
+    image: fusionauth/fusionauth-app:1.45.4
     environment:
       DATABASE_URL: jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/fusionauth
       DATABASE_ROOT_USERNAME: ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,43 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     ports:
       - 25532:5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
+  elasticsearch:
+    container_name: fa-test-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    environment:
+      - bootstrap.memory_lock=true
+      - cluster.name=elasticsearch-cluster
+      - discovery.type=single-node
+      - node.name=elasticsearch-01
+      - "ES_JAVA_OPTS=${ES_JAVA_OPTS}"
+    healthcheck:
+      interval: 10s
+      retries: 80
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200/
+    ports:
+      - 29300:9200
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+
   fusionauth:
     container_name: fa-test-fusionauth
-    image: fusionauth/fusionauth-app:1.35.0
+    # ISSUES    Upgrading to 45 returns 401 for some JWT endpoints that are currently in use.
+    # GOOD      Upgrading to 40 works with some minor test tweaks.
+    image: fusionauth/fusionauth-app:1.40.0
     environment:
       DATABASE_URL: jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/fusionauth
       DATABASE_ROOT_USERNAME: ${POSTGRES_USER}
@@ -30,31 +59,15 @@ services:
       # Kickstart Configuration
       FUSION_AUTH_API_KEY: ${FUSION_AUTH_API_KEY}
     depends_on:
-      - elasticsearch
-      - postgres
+      postgres:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     ports:
       - 29012:9011
     volumes:
       - fusionauth-config:/usr/local/fusionauth/config
       - ./priv/data/fusionauth:/usr/local/fusionauth/kickstart
-
-  elasticsearch:
-    container_name: fa-test-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
-    environment:
-      - bootstrap.memory_lock=true
-      - cluster.name=elasticsearch-cluster
-      - discovery.type=single-node
-      - node.name=elasticsearch-01
-      - "ES_JAVA_OPTS=${ES_JAVA_OPTS}"
-    ports:
-      - 29300:9200
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,9 @@ services:
 
   fusionauth:
     container_name: fa-test-fusionauth
-    # ISSUES    Upgrading to 45 returns 401 for some JWT endpoints that are currently in use.
-    # GOOD      Upgrading to 40 works with some minor test tweaks.
+    # GOOD      Upgrading to 1.40 works with some minor test tweaks.
+    # ISSUES    Upgrading to 1.45 returns 401 for some JWT endpoints that are currently in use.
+    # GOOD      Upgrading to 1.45.4 works with some minor test tweaks.
     image: fusionauth/fusionauth-app:1.45.4
     environment:
       DATABASE_URL: jdbc:postgresql://${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/fusionauth

--- a/lib/fusion_auth.ex
+++ b/lib/fusion_auth.ex
@@ -88,7 +88,7 @@ defmodule FusionAuth do
 
   @spec result({:ok, Tesla.Env.t()}) :: result()
   def result({:ok, %{status: status, body: body} = env}) when status >= 300 do
-    Logger.warn("""
+    Logger.warning("""
       FusionAuth request resulted in a status code >= 300.
       Env: #{inspect(env)}
     """)

--- a/lib/fusion_auth/jwt.ex
+++ b/lib/fusion_auth/jwt.ex
@@ -142,59 +142,6 @@ defmodule FusionAuth.JWT do
     |> FusionAuth.result()
   end
 
-  []
-
-  @doc """
-  Retrieve Refresh Tokens issued to a User by User ID
-
-  ## Examples
-      iex> FusionAuth.JWT.get_user_refresh_tokens_by_user_id(client, user_id)
-      {
-        :ok,
-        %{
-          "refreshTokens" => [...]
-        },
-        %Tesla.Env{...}
-      }
-
-  For more information, visit the FusionAuth API Documentation for [Retrieve Refresh Tokens](https://fusionauth.io/docs/v1/tech/apis/jwt#retrieve-refresh-tokens).
-  """
-  @spec get_user_refresh_tokens_by_user_id(client(), String.t()) :: result()
-  def get_user_refresh_tokens_by_user_id(client, user_id) do
-    parameters = [userId: user_id]
-
-    Tesla.get(client, @jwt_refresh_url <> Utils.build_query_parameters(parameters))
-    |> FusionAuth.result()
-  end
-
-  @doc """
-  Retrieve Refresh Tokens issued to a User
-
-  This API will use a JWT as authentication. See [JWT Authentication](https://fusionauth.io/docs/v1/tech/apis/authentication#jwt-authentication) for examples of how you can send the JWT to FusionAuth.
-
-  ## Examples
-      iex> FusionAuth.JWT.get_user_refresh_tokens(client, token)
-      {
-        :ok,
-        %{
-          "refreshTokens" => [...]
-        },
-        %Tesla.Env{...}
-      }
-
-  For more information, visit the FusionAuth API Documentation for [Retrieve Refresh Tokens](https://fusionauth.io/docs/v1/tech/apis/jwt#retrieve-refresh-tokens).
-  """
-  @spec get_user_refresh_tokens(client(), String.t()) :: result()
-  def get_user_refresh_tokens(client, token) do
-    client = jwt_client(client, "Bearer #{token}")
-
-    Tesla.get(
-      client,
-      @jwt_refresh_url
-    )
-    |> FusionAuth.result()
-  end
-
   @doc """
   Revoke all Refresh Tokens for an entire Application
 

--- a/lib/fusion_auth/plugs/authorize_jwt.ex
+++ b/lib/fusion_auth/plugs/authorize_jwt.ex
@@ -103,7 +103,9 @@ defmodule FusionAuth.Plugs.AuthorizeJWT do
         %{exp: claims["exp"], jti: claims["jti"]}
       )
     else
-      _ ->
+      other ->
+        IO.inspect(other, label: "other throwing 401")
+
         conn
         |> Plug.Conn.halt()
         |> Plug.Conn.send_resp(401, "Unauthorized")
@@ -128,6 +130,10 @@ defmodule FusionAuth.Plugs.AuthorizeJWT do
   defp verify_signature(token) do
     key = Application.get_env(:fusion_auth, :jwt_signing_key) |> Base.encode64()
     jwk = JWK.from(%{"kty" => "oct", "k" => key})
+
+    IO.inspect(token, label: "verify_signature token")
+    IO.inspect(key, label: "verify_signature key")
+    IO.inspect(jwk, label: "verify_signature jwk")
 
     case JWT.verify_strict(jwk, ["HS256"], token) do
       {false, _, _} ->

--- a/lib/fusion_auth/plugs/authorize_jwt.ex
+++ b/lib/fusion_auth/plugs/authorize_jwt.ex
@@ -103,9 +103,7 @@ defmodule FusionAuth.Plugs.AuthorizeJWT do
         %{exp: claims["exp"], jti: claims["jti"]}
       )
     else
-      other ->
-        IO.inspect(other, label: "other throwing 401")
-
+      _ ->
         conn
         |> Plug.Conn.halt()
         |> Plug.Conn.send_resp(401, "Unauthorized")
@@ -130,10 +128,6 @@ defmodule FusionAuth.Plugs.AuthorizeJWT do
   defp verify_signature(token) do
     key = Application.get_env(:fusion_auth, :jwt_signing_key) |> Base.encode64()
     jwk = JWK.from(%{"kty" => "oct", "k" => key})
-
-    IO.inspect(token, label: "verify_signature token")
-    IO.inspect(key, label: "verify_signature key")
-    IO.inspect(jwk, label: "verify_signature jwk")
 
     case JWT.verify_strict(jwk, ["HS256"], token) do
       {false, _, _} ->

--- a/test/fusion_auth/applications_test.exs
+++ b/test/fusion_auth/applications_test.exs
@@ -58,7 +58,8 @@ defmodule FusionAuth.ApplicationsTest do
               "message" => "You must specify the [application.name] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -182,7 +183,8 @@ defmodule FusionAuth.ApplicationsTest do
               "message" => "You must specify the [application.name] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       {:ok, initial_application, _} = Applications.create_application(client, @application)
@@ -285,7 +287,8 @@ defmodule FusionAuth.ApplicationsTest do
               "message" => "You must specify the [role.name] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       {:ok, application, _} = Applications.create_application(client, @application)
@@ -303,10 +306,11 @@ defmodule FusionAuth.ApplicationsTest do
             %{
               "code" => "[invalid]applicationId",
               "message" =>
-                "Invalid [applicationId] on the URL. No Application exists for Id [#{@invalid_application_id}]."
+                "Invalid [applicationId] on the URL. No application exists with Id [#{@invalid_application_id}]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -342,10 +346,11 @@ defmodule FusionAuth.ApplicationsTest do
             %{
               "code" => "[invalidJSON]",
               "message" =>
-                "Invalid JSON in the request body. The property was [role.isSuperRole]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `boolean` from String \"bogus\": only \"true\"/\"True\"/\"TRUE\" or \"false\"/\"False\"/\"FALSE\" recognized\n at [Source: (org.apache.catalina.connector.CoyoteInputStream); line: 1, column: 24] (through reference chain: io.fusionauth.domain.api.ApplicationRequest[\"role\"]->io.fusionauth.domain.ApplicationRole[\"isSuperRole\"])]."
+                "Invalid JSON in the request body. The property was [role.isSuperRole]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `boolean` from String \"bogus\": only \"true\"/\"True\"/\"TRUE\" or \"false\"/\"False\"/\"FALSE\" recognized\n at [Source: (byte[])\"{\"role\":{\"isSuperRole\":\"bogus\"}}\"; line: 1, column: 24] (through reference chain: io.fusionauth.domain.api.ApplicationRequest[\"role\"]->io.fusionauth.domain.ApplicationRole[\"isSuperRole\"])]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -367,10 +372,11 @@ defmodule FusionAuth.ApplicationsTest do
             %{
               "code" => "[invalid]applicationId",
               "message" =>
-                "Invalid [applicationId] on the URL. No Application exists for Id [32c54ee1-3d5a-4085-9ec5-4731d9e0f752]."
+                "Invalid [applicationId] on the URL. No application exists with Id [32c54ee1-3d5a-4085-9ec5-4731d9e0f752]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =

--- a/test/fusion_auth/applications_test.exs
+++ b/test/fusion_auth/applications_test.exs
@@ -346,7 +346,7 @@ defmodule FusionAuth.ApplicationsTest do
             %{
               "code" => "[invalidJSON]",
               "message" =>
-                "Invalid JSON in the request body. The property was [role.isSuperRole]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `boolean` from String \"bogus\": only \"true\"/\"True\"/\"TRUE\" or \"false\"/\"False\"/\"FALSE\" recognized\n at [Source: (byte[])\"{\"role\":{\"isSuperRole\":\"bogus\"}}\"; line: 1, column: 24] (through reference chain: io.fusionauth.domain.api.ApplicationRequest[\"role\"]->io.fusionauth.domain.ApplicationRole[\"isSuperRole\"])]."
+                "Invalid JSON in the request body. The property was [role.isSuperRole]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `boolean` from String \"bogus\": only \"true\"/\"True\"/\"TRUE\" or \"false\"/\"False\"/\"FALSE\" recognized\n at [Source: (io.fusionauth.http.io.ReaderBlockingByteBufferInputStream); line: 1, column: 24] (through reference chain: io.fusionauth.domain.api.ApplicationRequest[\"role\"]->io.fusionauth.domain.ApplicationRole[\"isSuperRole\"])]."
             }
           ]
         },

--- a/test/fusion_auth/audit_logs_test.exs
+++ b/test/fusion_auth/audit_logs_test.exs
@@ -46,7 +46,8 @@ defmodule FusionAuth.AuditLogsTest do
               "message" => "You must specify the [auditLog.message] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =

--- a/test/fusion_auth/groups_test.exs
+++ b/test/fusion_auth/groups_test.exs
@@ -97,7 +97,8 @@ defmodule FusionAuth.GroupsTest do
               "message" => "A group with the name [Test Group] already exists."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       Groups.create_group(client, @group)

--- a/test/fusion_auth/jwt_test.exs
+++ b/test/fusion_auth/jwt_test.exs
@@ -98,42 +98,6 @@ defmodule FusionAuth.JWTTest do
     end
   end
 
-  describe "Retrieve Refresh Tokens issued to a User by User ID" do
-    test "get_user_refresh_tokens_by_user_id/2 returns a 200 status code for successful request",
-         %{client: client} do
-      TestUtilities.wait_for_process(fn ->
-        {status, _, _} = FusionAuth.Users.get_user_by_id(client, @user_id)
-        if status == :ok, do: :continue, else: :wait
-      end)
-
-      assert {:ok, %{}, %Tesla.Env{status: 200}} =
-               JWT.get_user_refresh_tokens_by_user_id(client, @user_id)
-    end
-
-    test "get_user_refresh_tokens_by_user_id/2 returns a 401 status code for incorrect Authorization header",
-         %{base_url: base_url} do
-      client = FusionAuth.client(base_url, "", "")
-
-      assert {:error, "", %Tesla.Env{status: 401}} =
-               JWT.get_user_refresh_tokens_by_user_id(client, @user_id)
-    end
-  end
-
-  describe "Retrieve Refresh Tokens issued to a User" do
-    test "get_user_refresh_tokens/2 returns a 200 status code for a successful request", %{
-      client: client,
-      token: token
-    } do
-      assert {:ok, %{}, %Tesla.Env{status: 200}} = JWT.get_user_refresh_tokens(client, token)
-    end
-
-    test "get_user_refresh_tokens/2 returns a 401 status code for an invalid token",
-         %{client: client} do
-      assert {:error, "", %Tesla.Env{status: 401}} =
-               JWT.get_user_refresh_tokens(client, "bad-token")
-    end
-  end
-
   describe "Revoke all Refresh Tokens for an entire Application by Application ID" do
     test "revoke_refresh_tokens_by_application_id/2 returns a 200 status code for a successful request",
          %{client: client} do
@@ -165,10 +129,11 @@ defmodule FusionAuth.JWTTest do
             %{
               "code" => "[invalid]userId",
               "message" =>
-                "Invalid [userId] property. No user exists with an Id [25a872da-bb44-4af8-a43d-e7bcb5351ebc]."
+                "The [userId] property is not valid. No user exists with an Id [25a872da-bb44-4af8-a43d-e7bcb5351ebc]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^error, %Tesla.Env{status: 400}} =

--- a/test/fusion_auth/plugs/authorize_jwt_test.exs
+++ b/test/fusion_auth/plugs/authorize_jwt_test.exs
@@ -4,9 +4,9 @@ defmodule FusionAuth.Plugs.AuthorizeJWTTest do
   alias FusionAuth.Plugs.AuthorizeJWT
   alias FusionAuth.TestUtilities
 
-  @base_url Application.get_env(:fusion_auth, :api_url)
-  @api_key Application.get_env(:fusion_auth, :api_key)
-  @tenant_id Application.get_env(:fusion_auth, :tenant_id)
+  @base_url Application.compile_env(:fusion_auth, :api_url)
+  @api_key Application.compile_env(:fusion_auth, :api_key)
+  @tenant_id Application.compile_env(:fusion_auth, :tenant_id)
   @application_id "861f5558-34a8-43e4-ab50-317bdcd47671"
   @key_id "b2cd1a09-6929-45a9-a172-9ec6523469f9"
   @jwt_signing_key_secret "secret"

--- a/test/fusion_auth/registrations_test.exs
+++ b/test/fusion_auth/registrations_test.exs
@@ -75,7 +75,8 @@ defmodule FusionAuth.RegistrationsTest do
               "message" => "You must specify the [registration.applicationId] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -104,7 +105,8 @@ defmodule FusionAuth.RegistrationsTest do
                 "The user with Id [00000000-0000-0000-0000-00000001e240] does not exist."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -180,7 +182,8 @@ defmodule FusionAuth.RegistrationsTest do
               "message" => "The Id of the User was not specified on the URL."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -300,7 +303,8 @@ defmodule FusionAuth.RegistrationsTest do
               "message" => "You must specify the [registration.applicationId] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       data = %{
@@ -407,7 +411,8 @@ defmodule FusionAuth.RegistrationsTest do
               "message" => "You must specify the [applicationId] as a parameter."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^resp_body, %Tesla.Env{status: 400}} =

--- a/test/fusion_auth/users_test.exs
+++ b/test/fusion_auth/users_test.exs
@@ -138,7 +138,8 @@ defmodule FusionAuth.UsersTest do
                 "You must specify either the [user.email] or [user.username] property. If you are emailing the user you must specify the [user.email]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} = Users.create_user(client, user)
@@ -178,7 +179,8 @@ defmodule FusionAuth.UsersTest do
                 "You must specify either the [user.email] or [user.username] property. If you are emailing the user you must specify the [user.email]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       {:ok, user, _} = Users.create_user(client, @user)
@@ -270,7 +272,8 @@ defmodule FusionAuth.UsersTest do
                 "You must specify either the [user.email] or [user.username] property for each user."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} = Users.import_users(client, users)
@@ -315,7 +318,8 @@ defmodule FusionAuth.UsersTest do
             "code" => "[invalid]",
             "message" => "You must specify either the [ids], [queryString], or [query] property."
           }
-        ]
+        ],
+        "fieldErrors" => %{}
       }
 
       assert {:error, ^response_body, %Tesla.Env{status: 400}} =
@@ -371,10 +375,11 @@ defmodule FusionAuth.UsersTest do
             %{
               "code" => "[invalidJSON]",
               "message" =>
-                "Invalid JSON in the request body. The property was [loginId]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)\n at [Source: (org.apache.catalina.connector.CoyoteInputStream); line: 1, column: 12] (through reference chain: io.fusionauth.domain.api.user.ForgotPasswordRequest[\"loginId\"])]."
+                "Invalid JSON in the request body. The property was [loginId]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)\n at [Source: (byte[])\"{\"loginId\":{}}\"; line: 1, column: 12] (through reference chain: io.fusionauth.domain.api.user.ForgotPasswordRequest[\"loginId\"])]."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^error, %Tesla.Env{status: 400}} = Users.forgot_password(client, login_id)
@@ -412,7 +417,8 @@ defmodule FusionAuth.UsersTest do
               "message" => "You must specify the [password] property."
             }
           ]
-        }
+        },
+        "generalErrors" => []
       }
 
       assert {:error, ^error, %Tesla.Env{status: 400}} =
@@ -446,7 +452,8 @@ defmodule FusionAuth.UsersTest do
             "message" =>
               "Your request is invalid. You must call the API with a valid JSON body that includes a changePasswordId, with a valid JWT in the Authorization header or with an API key."
           }
-        ]
+        ],
+        "fieldErrors" => %{}
       }
 
       assert {:error, ^error, %Tesla.Env{status: 400}} =

--- a/test/fusion_auth/users_test.exs
+++ b/test/fusion_auth/users_test.exs
@@ -299,10 +299,10 @@ defmodule FusionAuth.UsersTest do
       }
 
       assert TestUtilities.wait_for_process(fn ->
-               {:ok, %{"total" => count}, %Tesla.Env{status: 200}} =
+               {:ok, %{"users" => users}, %Tesla.Env{status: 200}} =
                  Users.search_users(client, search)
 
-               if count == 2, do: :continue, else: :wait
+               if length(users) == 2, do: :continue, else: :wait
              end)
     end
 

--- a/test/fusion_auth/users_test.exs
+++ b/test/fusion_auth/users_test.exs
@@ -375,7 +375,7 @@ defmodule FusionAuth.UsersTest do
             %{
               "code" => "[invalidJSON]",
               "message" =>
-                "Invalid JSON in the request body. The property was [loginId]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)\n at [Source: (byte[])\"{\"loginId\":{}}\"; line: 1, column: 12] (through reference chain: io.fusionauth.domain.api.user.ForgotPasswordRequest[\"loginId\"])]."
+                "Invalid JSON in the request body. The property was [loginId]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)\n at [Source: (io.fusionauth.http.io.ReaderBlockingByteBufferInputStream); line: 1, column: 12] (through reference chain: io.fusionauth.domain.api.user.ForgotPasswordRequest[\"loginId\"])]."
             }
           ]
         },


### PR DESCRIPTION
## Jira Issue(s)

VR-14247

## How to Test

- `./run test` to ensure all tests are passing.
- This will be testable by virtue of pulling in this updated package to `verus_server` via VR-14251.

## Release Tasks

N/A

## Environment Variables

N/A

## Dependencies

N/A